### PR TITLE
Remove type annotations from react-redux#connect

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -775,6 +775,18 @@ const transform = {
         declaration
       });
     }
+  },
+  CallExpression: {
+    exit(path) {
+      const { callee } = path.node;
+
+      // Flow's react-redux#connect types are not compatible to typescripts. TS
+      // does a good job interferencing the correct types for the call so remove
+      // the type definition
+      if (callee.name == "connect") {
+        delete path.node.typeArguments;
+      }
+    }
   }
 };
 

--- a/test/fixtures/convert/react-redux/connect/flow.js
+++ b/test/fixtures/convert/react-redux/connect/flow.js
@@ -1,0 +1,2 @@
+// @flow
+export default connect<Props, MapStateToProps, _, _, _, _>(mapStateToProps)(Component);

--- a/test/fixtures/convert/react-redux/connect/ts.js
+++ b/test/fixtures/convert/react-redux/connect/ts.js
@@ -1,0 +1,2 @@
+
+export default connect(mapStateToProps)(Component);


### PR DESCRIPTION
Flow's react-redux#connect types are not compatible to typescripts. TS does a good job interferencing the correct types for the call so remove the type definition